### PR TITLE
feather: change shebang to use python2

### DIFF
--- a/feather
+++ b/feather
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 


### PR DESCRIPTION
The shebang line was set to use the default python interpreter. If
this is python 3 the execution of feather was failing because the
script is not python 3 compatible.

Change the shebang to use a python 2 interpreter by default.