### PR TITLE
Fix --dry-run from a broken state.

### DIFF
--- a/feather
+++ b/feather
@@ -266,7 +266,7 @@ class pr_tarsnap(object):
         self.handle = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE)
         (stdout, stderr) = self.handle.communicate()
-        if self.handle.returncode > 0:
+        if (self.verbosity > 0 and self.dry_run) or self.handle.returncode > 0:
             print stderr
         return stdout
 
@@ -304,6 +304,8 @@ class pr_tarsnap(object):
                 if self.verbosity > 0:
                     print "Taking backup", archive_name
                 cmd = self.tarsnap_cmd()
+                if self.dry_run:
+                    cmd += ["--dry-run"]
                 if self.backup_args:
                     cmd += self.backup_args
                 cmd += ["-c", "-f", archive_name]
@@ -319,8 +321,6 @@ class pr_tarsnap(object):
                     cmd.extend(backup_path)
                 else:
                     cmd += [backup_path]
-                if self.dry_run:
-                    cmd += ["--dry-run"]
                 if self.verbosity > 2:
                     print cmd
                 output = self.execute(cmd)


### PR DESCRIPTION
  - tarsnap requires --dry-run to come before paths, it does now.
  - If --dry-run is present, and verbosity is on, output stderr
    so the user will be presented with the size analysis from
    tarsnap.
  - Without verbosity, --dry-run gives no output but allows the
    user to check for valid syntax.

There is a question as to --dry-run should also default to printing the actual tarsnap command, but that still requires verbosity > 2 and --dry-run does nothing towards that right now.