### PR TITLE
Generate a unique pid lock file per config location

### DIFF
--- a/feather
+++ b/feather
@@ -23,7 +23,9 @@ Generous support for feather was provided by Prometheus Research, LLC
 '''
 
 
+import base64
 import datetime
+import hashlib
 import optparse
 import os
 import re
@@ -454,7 +456,12 @@ def main():
     if len(args) != 1:
         parser.error("YAML config file not specified")
 
-    PIDFILE = "/tmp/feather.pid"
+    # Generate a unique pid lock file per config location
+    config_path = os.path.realpath(args[0])
+    PIDFILE = "/tmp/feather-%s.pid" % base64.b64encode(
+                                        hashlib.sha1(
+                                          config_path).digest())[:8]
+
     lock(PIDFILE)
     os.nice(20)
     b = pr_tarsnap(args[0], options.verbosity, options.dry_run)

--- a/feather
+++ b/feather
@@ -22,8 +22,6 @@ Generous support for feather was provided by Prometheus Research, LLC
 
 '''
 
-
-import base64
 import datetime
 import hashlib
 import optparse
@@ -458,9 +456,7 @@ def main():
 
     # Generate a unique pid lock file per config location
     config_path = os.path.realpath(args[0])
-    PIDFILE = "/tmp/feather-%s.pid" % base64.b64encode(
-                                        hashlib.sha1(
-                                          config_path).digest())[:8]
+    PIDFILE = "/tmp/feather-%s.pid" % hashlib.md5(config_path).hexdigest()[:8]
 
     lock(PIDFILE)
     os.nice(20)


### PR DESCRIPTION
Instead of hard coding the pid file, generate a pid file name based on
a short hash of the fully qualified path to the config file being
specified. This allows multiple tarsnaps to run at the same time, using
distinct configs.

Resolves #10 